### PR TITLE
Added a way to adjust resolvconf options

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -62,3 +62,10 @@ suites:
     verifier:
       name: shell
       command: rspec -c -f d -I tests/serverspec tests/serverspec/default_spec.rb
+  - name: options
+    provisioner:
+      name: ansible_playbook
+      playbook: tests/serverspec/options.yml
+    verifier:
+      name: shell
+      command: rspec -c -f d -I tests/serverspec tests/serverspec/options_spec.rb

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ None
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `resolver_nameservers` | list of resolvers | `[]` |
+| `resolver_options`     | list of options   | `[]` |
 
 # Dependencies
 
@@ -41,6 +42,10 @@ None
       - 192.168.1.2
       - 192.168.1.3
     resolver_nameservers: "{{ nameservers | predictable_shuffle(ansible_fqdn) | list }}"
+    resolver_options:
+      - timeout:1
+      - attempts:1
+      - rotate
 ```
 
 # License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,2 @@
 resolver_nameservers: []
+resolver_options: []

--- a/templates/resolv.conf.j2
+++ b/templates/resolv.conf.j2
@@ -1,7 +1,6 @@
 {% for n in resolver_nameservers %}
 nameserver {{ n }}
 {% endfor %}
-
 {% if resolver_options | length %}
 options {{ resolver_options | join(' ') }}
 {% endif %}

--- a/templates/resolv.conf.j2
+++ b/templates/resolv.conf.j2
@@ -1,3 +1,7 @@
 {% for n in resolver_nameservers %}
 nameserver {{ n }}
 {% endfor %}
+
+{% if resolver_options | length %}
+options {{ resolver_options | join(' ') }}
+{% endif %}

--- a/templates/resolvconf.conf.j2
+++ b/templates/resolvconf.conf.j2
@@ -1,1 +1,4 @@
 name_servers="{{ resolver_nameservers | join(' ') }}"
+{% if resolver_options | length %}
+resolv_conf_options="{{ resolver_options | join(' ') }}"
+{% endif %}

--- a/tests/serverspec/options.yml
+++ b/tests/serverspec/options.yml
@@ -23,3 +23,6 @@
       - 192.168.1.2
       - 192.168.1.3
     resolver_nameservers: "{{ nameservers | predictable_shuffle(ansible_fqdn) | list }}"
+    resolver_options:
+      - timeout:1
+      - rotate

--- a/tests/serverspec/options_spec.rb
+++ b/tests/serverspec/options_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 case os[:family]
 when "freebsd"
   describe file("/etc/resolvconf.conf") do
-    its(:content) { should match(/name_servers="192\.168\.1\.2 192\.168\.1\.3 192\.168\.1\.1"\n\nresolv_conf_options="timeout:1 rotate"/) }
+    its(:content) { should match(/name_servers="192\.168\.1\.2 192\.168\.1\.3 192\.168\.1\.1"\nresolv_conf_options="timeout:1 rotate"/) }
   end
 end
 
@@ -11,15 +11,15 @@ describe file("/etc/resolv.conf") do
   its(:content) { should_not match(/nameserver\s+#{ Regexp.escape('10.0.2.3') }/) }
   case host_inventory["fqdn"]
   when "default-freebsd-103-amd64"
-    its(:content) { should match(/nameserver 192\.168\.1\.2\nnameserver 192\.168\.1\.3\nnameserver 192\.168\.1\.1\n\noptions timeout:1 rotate/) }
+    its(:content) { should match(/nameserver 192\.168\.1\.2\nnameserver 192\.168\.1\.3\nnameserver 192\.168\.1\.1\noptions timeout:1 rotate/) }
   when "default-openbsd-60-amd64"
-    its(:content) { should match(/nameserver 192\.168\.1\.2\nnameserver 192\.168\.1\.1\nnameserver 192\.168\.1\.3\n\noptions timeout:1 rotate/) }
+    its(:content) { should match(/nameserver 192\.168\.1\.2\nnameserver 192\.168\.1\.1\nnameserver 192\.168\.1\.3\noptions timeout:1 rotate/) }
   when "default-ubuntu-1404-amd64"
-    its(:content) { should match(/nameserver 192\.168\.1\.3\nnameserver 192\.168\.1\.2\nnameserver 192\.168\.1\.1\n\noptions timeout:1 rotate/) }
+    its(:content) { should match(/nameserver 192\.168\.1\.3\nnameserver 192\.168\.1\.2\nnameserver 192\.168\.1\.1\noptions timeout:1 rotate/) }
   when "default-centos-73-x86-64"
-    its(:content) { should match(/nameserver 192\.168\.1\.3\nnameserver 192\.168\.1\.1\nnameserver 192\.168\.1\.2\n\noptions timeout:1 rotate/) }
+    its(:content) { should match(/nameserver 192\.168\.1\.3\nnameserver 192\.168\.1\.1\nnameserver 192\.168\.1\.2\noptions timeout:1 rotate/) }
   else
-    its(:content) { should match(/nameserver 192\.168\.1\.2\nnameserver 192\.168\.1\.3\nnameserver 192\.168\.1\.1\n\noptions timeout:1 rotate/) }
+    its(:content) { should match(/nameserver 192\.168\.1\.2\nnameserver 192\.168\.1\.3\nnameserver 192\.168\.1\.1\noptions timeout:1 rotate/) }
   end
 end
 # 2 1 3

--- a/tests/serverspec/options_spec.rb
+++ b/tests/serverspec/options_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+case os[:family]
+when "freebsd"
+  describe file("/etc/resolvconf.conf") do
+    its(:content) { should match(/name_servers="192\.168\.1\.2 192\.168\.1\.3 192\.168\.1\.1"\n\nresolv_conf_options="timeout:1 rotate"/) }
+  end
+end
+
+describe file("/etc/resolv.conf") do
+  its(:content) { should_not match(/nameserver\s+#{ Regexp.escape('10.0.2.3') }/) }
+  case host_inventory["fqdn"]
+  when "default-freebsd-103-amd64"
+    its(:content) { should match(/nameserver 192\.168\.1\.2\nnameserver 192\.168\.1\.3\nnameserver 192\.168\.1\.1\n\noptions timeout:1 rotate/) }
+  when "default-openbsd-60-amd64"
+    its(:content) { should match(/nameserver 192\.168\.1\.2\nnameserver 192\.168\.1\.1\nnameserver 192\.168\.1\.3\n\noptions timeout:1 rotate/) }
+  when "default-ubuntu-1404-amd64"
+    its(:content) { should match(/nameserver 192\.168\.1\.3\nnameserver 192\.168\.1\.2\nnameserver 192\.168\.1\.1\n\noptions timeout:1 rotate/) }
+  when "default-centos-73-x86-64"
+    its(:content) { should match(/nameserver 192\.168\.1\.3\nnameserver 192\.168\.1\.1\nnameserver 192\.168\.1\.2\n\noptions timeout:1 rotate/) }
+  else
+    its(:content) { should match(/nameserver 192\.168\.1\.2\nnameserver 192\.168\.1\.3\nnameserver 192\.168\.1\.1\n\noptions timeout:1 rotate/) }
+  end
+end
+# 2 1 3


### PR DESCRIPTION
Added `resolver_options` variable in order to set options like `timeout`, `rotate`, etc. to the resolv.conf. Fixes: https://github.com/reallyenglish/ansible-role-resolver/issues/14