### PR TITLE
Added a way to adjust resolvconf search domains

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -62,3 +62,10 @@ suites:
     verifier:
       name: shell
       command: rspec -c -f d -I tests/serverspec tests/serverspec/default_spec.rb
+  - name: search
+    provisioner:
+      name: ansible_playbook
+      playbook: tests/serverspec/search.yml
+    verifier:
+      name: shell
+      command: rspec -c -f d -I tests/serverspec tests/serverspec/search_spec.rb

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ None
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `resolver_nameservers` | list of resolvers | `[]` |
+| `resolver_search_domains`     | list of search domains   | `[]` |
 
 # Dependencies
 
@@ -41,6 +42,9 @@ None
       - 192.168.1.2
       - 192.168.1.3
     resolver_nameservers: "{{ nameservers | predictable_shuffle(ansible_fqdn) | list }}"
+    resolver_search_domains:
+      - example.com
+      - example.net
 ```
 
 # License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,2 @@
 resolver_nameservers: []
+resolver_search_domains: []

--- a/templates/resolv.conf.j2
+++ b/templates/resolv.conf.j2
@@ -1,3 +1,6 @@
 {% for n in resolver_nameservers %}
 nameserver {{ n }}
 {% endfor %}
+{% if resolver_search_domains | length %}
+search {{ resolver_search_domains | join(' ') }}
+{% endif %}

--- a/templates/resolvconf.conf.j2
+++ b/templates/resolvconf.conf.j2
@@ -1,1 +1,4 @@
 name_servers="{{ resolver_nameservers | join(' ') }}"
+{% if resolver_search_domains | length %}
+search_domains="{{ resolver_search_domains | join(' ') }}"
+{% endif %}

--- a/tests/serverspec/search.yml
+++ b/tests/serverspec/search.yml
@@ -23,3 +23,6 @@
       - 192.168.1.2
       - 192.168.1.3
     resolver_nameservers: "{{ nameservers | predictable_shuffle(ansible_fqdn) | list }}"
+    resolver_search_domains:
+      - example.com
+      - example.net

--- a/tests/serverspec/search_spec.rb
+++ b/tests/serverspec/search_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+case os[:family]
+when "freebsd"
+  describe file("/etc/resolvconf.conf") do
+    its(:content) { should match(/name_servers="192\.168\.1\.2 192\.168\.1\.3 192\.168\.1\.1"\nsearch_domains="example\.com example\.net"/) }
+  end
+end
+
+describe file("/etc/resolv.conf") do
+  its(:content) { should_not match(/nameserver\s+#{ Regexp.escape('10.0.2.3') }/) }
+  case host_inventory["fqdn"]
+  when "default-freebsd-103-amd64"
+    its(:content) { should match(/nameserver 192\.168\.1\.2\nnameserver 192\.168\.1\.3\nnameserver 192\.168\.1\.1\nsearch example\.com example\.net/) }
+  when "default-openbsd-60-amd64"
+    its(:content) { should match(/nameserver 192\.168\.1\.2\nnameserver 192\.168\.1\.1\nnameserver 192\.168\.1\.3\nsearch example\.com example\.net/) }
+  when "default-ubuntu-1404-amd64"
+    its(:content) { should match(/nameserver 192\.168\.1\.3\nnameserver 192\.168\.1\.2\nnameserver 192\.168\.1\.1\nsearch example\.com example\.net/) }
+  when "default-centos-73-x86-64"
+    its(:content) { should match(/nameserver 192\.168\.1\.3\nnameserver 192\.168\.1\.1\nnameserver 192\.168\.1\.2\nsearch example\.com example\.net/) }
+  else
+    its(:content) { should match(/nameserver 192\.168\.1\.2\nnameserver 192\.168\.1\.3\nnameserver 192\.168\.1\.1\nsearch example\.com example\.net/) }
+  end
+end
+# 2 1 3


### PR DESCRIPTION
added `resolver_search_domains` variable in order to set search domains like `example.com`, `example.net`, etc. to the resolv.conf

fixes: https://github.com/reallyenglish/ansible-role-resolver/issues/17